### PR TITLE
fix: adding streamable-http as related to toolhive deployment

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,7 @@ const config: Partial<LoxoneConfig> = {
   
   switch (transport.toLowerCase()) {
     case 'http':
+    case 'streamable-http':
     case 'streamablehttp':
       const { LoxoneHttpServer } = await import('./http-server.js');
       server = new LoxoneHttpServer(config);


### PR DESCRIPTION
toolhive  sets the `MCP_TRANSPORT` variable to `streamable-http`